### PR TITLE
Upgrade to JavaRosa v2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     exclude group: 'commons-logging'
   }
   compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-  compile(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.15.1') {
+  compile(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.16.0') {
     exclude group: 'org.slf4j'
   }
   compile group: 'org.hsqldb', name: 'hsqldb', version: '2.4.0'


### PR DESCRIPTION
JavaRosa built with AdoptOpenJDK 1.8.0_222 and Briefcase run with Open JDK 11.0.2 2019-01-15.

Confirmed working by downloading and exporting an encrypted submission from Aggregate.