### PR TITLE
Never randomize choice lists to ensure stable export order

### DIFF
--- a/src/org/opendatakit/briefcase/export/FormDefinition.java
+++ b/src/org/opendatakit/briefcase/export/FormDefinition.java
@@ -136,6 +136,8 @@ public class FormDefinition {
             // instance that is not external
             if (secondaryInstance != null && !(secondaryInstance instanceof ExternalDataInstance))
               try {
+                // Never randomize the choice order to ensure stable column order when using split select multiples
+                itemsetBinding.randomize = false;
                 formDef.populateDynamicChoices(itemsetBinding, (TreeReference) control.getBind().getReference());
               } catch (NullPointerException e) {
                 // Ignore (see https://github.com/opendatakit/briefcase/issues/789)

--- a/test/java/org/opendatakit/briefcase/export/ExportToCsvExplodeRandomizedChoiceListTest.java
+++ b/test/java/org/opendatakit/briefcase/export/ExportToCsvExplodeRandomizedChoiceListTest.java
@@ -1,0 +1,25 @@
+package org.opendatakit.briefcase.export;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExportToCsvExplodeRandomizedChoiceListTest {
+  private ExportToCsvScenario scenario;
+
+  @Before
+  public void setUp() {
+    scenario = ExportToCsvScenario.setUp("choice-lists-randomize");
+  }
+
+  @After
+  public void tearDown() {
+    scenario.tearDown();
+  }
+
+  @Test
+  public void exportWithSplitSelectMultiple_hasStableColumnOrder() {
+    scenario.runExportExplodedChoiceLists();
+    scenario.assertSameContent();
+  }
+}

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-randomize-submission.xml
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-randomize-submission.xml
@@ -1,0 +1,6 @@
+<data id="choice-lists-randomize" instanceID="uuid:39f3dd36-161e-47cb-a1a4-395831d253a7" submissionDate="2020-04-26T08:58:20.525Z">
+  <select_multiple>a</select_multiple>
+  <n0:meta xmlns:n0="http://openrosa.org/xforms">
+    <n0:instanceID>uuid:39f3dd36-161e-47cb-a1a4-395831d253a7</n0:instanceID>
+  </n0:meta>
+</data>

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-randomize.csv.expected
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-randomize.csv.expected
@@ -1,0 +1,2 @@
+SubmissionDate,select_multiple,select_multiple/a,select_multiple/b,select_multiple/c,select_multiple/d,select_multiple/e,meta-instanceID,KEY
+"Apr 26, 2020 8:58:20 AM",a,1,0,0,0,0,uuid:39f3dd36-161e-47cb-a1a4-395831d253a7,uuid:39f3dd36-161e-47cb-a1a4-395831d253a7

--- a/test/resources/org/opendatakit/briefcase/export/choice-lists-randomize.xml
+++ b/test/resources/org/opendatakit/briefcase/export/choice-lists-randomize.xml
@@ -1,0 +1,49 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms">
+  <h:head>
+    <h:title>Randomize choice list</h:title>
+    <model>
+      <instance>
+        <data id="choice-lists-randomize">
+          <select_multiple/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <instance id="choices">
+        <root>
+          <item>
+            <name>a</name>
+            <label>A</label>
+          </item>
+          <item>
+            <name>b</name>
+            <label>B</label>
+          </item>
+          <item>
+            <name>c</name>
+            <label>C</label>
+          </item>
+          <item>
+            <name>d</name>
+            <label>D</label>
+          </item>
+          <item>
+            <name>e</name>
+            <label>E</label>
+          </item>
+        </root>
+      </instance>
+      <bind nodeset="/data/select_multiple" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <select ref="/data/select_multiple">
+      <itemset nodeset="randomize(instance('choices')/root/item)">
+        <value ref="name"/>
+        <label ref="label"/>
+      </itemset>
+    </select>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Closes #862

#### What has been done to verify that this works as intended?
Wrote and ran automated test. I also used the form linked in the issue discussion to send real submissions and verify the behavior at the command line with the smart append feature. However, the problem really ended up being just about the interaction with choice list randomization and the split select multiples feature.

#### Why is this the best possible solution? Were any other approaches considered?
The way that choice list randomization is implemented in JavaRosa is admittedly a hack. It's the best we could come up with at the time and I took advantage of that approach to ensure that the randomization never happens when using Briefcase. I don't love that this means I'm using a public boolean field on `ItemsetBinding` but I don't see an alternative and I think it can be revised if ever the JavaRosa implementation is improved.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only intended change is to fix the bug. The only code change is to set the `ItemsetBinding.randomize` field to false. I don't see any risk.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.
