### PR TITLE
Push Central attachments to draft endpoint and publish draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ There are example configuration files that you can use while developing:
 - Copy `res/logback.xml.example` to `res/logback.xml`. This conf will be used when launching Briefcase on your machine.
 
 ### Logging tests vs development vs release
-During the release process, we use a specific logback for release. This configuration sends exceptions to Sentry.io and also logs to a `briefcase.log` file, created in the same folder where Briefcase is launched by the user.
+During the release process, we use a specific logback configuration which logs to a `briefcase.log` file in the folder Briefcase is launched from.
 
 For testing and development purposes, customization of logback conf files is encouraged, especially to filter different levels of logging for specific packages. The following example sets the default level to `INFO` and `DEBUG` for components under `org.opendatakit`:
 

--- a/src/org/opendatakit/briefcase/push/central/PushToCentral.java
+++ b/src/org/opendatakit/briefcase/push/central/PushToCentral.java
@@ -99,6 +99,7 @@ public class PushToCentral {
               formAttachments.forEach(attachment ->
                   pushFormAttachment(form.getFormId(), attachment, rs, tracker, attachmentSeq.getAndIncrement(), totalAttachments)
               );
+              publishDraft(form.getFormId(), rs, tracker);
             }
           }
         }))
@@ -201,6 +202,19 @@ public class PushToCentral {
       tracker.trackFormAttachmentAlreadyExists(attachmentNumber, totalAttachments);
     else
       tracker.trackErrorSendingFormAttachment(attachmentNumber, totalAttachments, response);
+  }
+
+  void publishDraft(String formId, RunnerStatus runnerStatus, PushToCentralTracker tracker) {
+    if (runnerStatus.isCancelled()) {
+      tracker.trackCancellation("Publish form");
+      return;
+    }
+
+    Response response = http.execute(server.getPublishDraftRequest(formId, token));
+    if (response.isSuccess())
+      tracker.trackSuccessfulPublish();
+    else
+      tracker.trackErrorPublishing(response);
   }
 
   boolean pushSubmission(String formId, Path submissionFile, RunnerStatus runnerStatus, PushToCentralTracker tracker, int submissionNumber, int totalSubmissions) {

--- a/src/org/opendatakit/briefcase/push/central/PushToCentralTracker.java
+++ b/src/org/opendatakit/briefcase/push/central/PushToCentralTracker.java
@@ -163,8 +163,24 @@ class PushToCentralTracker {
     errored = true;
     String centralErrorMessage = parseErrorResponse(response.getServerErrorResponse());
     String message = "Error sending form attachment " + attachmentNumber + " of " + totalAttachments;
-    form.setStatusString(message + ": " + response.getStatusPhrase());
+    String helpFor404 = " This version of Briefcase supports Central v0.8 and up. " +
+        "If your Central server doesn't have form drafts, please either upgrade Central to v0.8 or higher or downgrade Briefcase to v1.17.4 or lower.";
+    form.setStatusString(message + ": " + response.getStatusPhrase() + (response.getStatusCode() == 404 ? helpFor404 : ""));
     log.error("Push {} - {} HTTP {} {} {}", form.getFormName(), message, response.getStatusCode(), response.getStatusPhrase(), centralErrorMessage);
+    notifyTrackingEvent();
+  }
+
+  void trackSuccessfulPublish() {
+    String message = "Form published";
+    form.setStatusString(message);
+    log.info("Push {} - {}", form.getFormName(), message);
+    notifyTrackingEvent();
+  }
+
+  void trackErrorPublishing(Response response) {
+    String message = "Error publishing form";
+    form.setStatusString(message + ": " + response.getStatusPhrase());
+    log.info("Push {} - {}", form.getFormName(), message);
     notifyTrackingEvent();
   }
 

--- a/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
@@ -184,10 +184,21 @@ public class CentralServer implements RemoteServer {
     return RequestBuilder.post(baseUrl)
         .asJsonMap()
         .withIgnoreCookies()
-        .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/attachments/" + attachment.getFileName().toString())
+        .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/draft/attachments/" + attachment.getFileName().toString())
         .withHeader("Authorization", "Bearer " + token)
         .withHeader("Content-Type", "*/*")
         .withBody(newInputStream(attachment))
+        .build();
+  }
+
+  public Request<Map<String, Object>> getPublishDraftRequest(String formId, String token) {
+    return RequestBuilder.post(baseUrl)
+        .asJsonMap()
+        .withIgnoreCookies()
+        .withPath("/v1/projects/" + projectId + "/forms/" + formId + "/draft/publish")
+        .withHeader("Authorization", "Bearer " + token)
+        .withHeader("Content-Type", "*/*")
+        .withBody("")
         .build();
   }
 

--- a/test/java/org/opendatakit/briefcase/push/central/PushToCentralTest.java
+++ b/test/java/org/opendatakit/briefcase/push/central/PushToCentralTest.java
@@ -163,13 +163,14 @@ public class PushToCentralTest {
 
 
   @Test
-  public void knows_how_to_push_completely_a_form_when_the_form_doesn_exist_in_Central() {
+  public void knows_how_to_push_completely_a_form_when_the_form_doesnt_exist_in_Central() {
     // High-level test that drives the public push operation
     http.stub(server.getFormExistsRequest(formStatus.getFormId(), token), ok(listOfFormsResponseFromCentral()));
     http.stub(server.getPushFormRequest(form, token), ok("{}"));
     http.stub(server.getPushFormAttachmentRequest(formStatus.getFormId(), formAttachment, token), ok("{}"));
     http.stub(server.getPushSubmissionRequest(token, formStatus.getFormId(), submission), ok("{}"));
     http.stub(server.getPushSubmissionAttachmentRequest(token, formStatus.getFormId(), instanceId, submissionAttachment), ok("{}"));
+    http.stub(server.getPublishDraftRequest(formStatus.getFormId(), token), ok("{}"));
 
     launchSync(pushOp.push(formStatus));
 
@@ -182,6 +183,7 @@ public class PushToCentralTest {
         hasItem("Submission 1 of 1 sent"),
         hasItem("Sending attachment 1 of 1 of submission 1 of 1"),
         hasItem("Attachment 1 of 1 of submission 1 of 1 sent"),
+        hasItem("Form published"),
         hasItem("Success")
     ));
   }


### PR DESCRIPTION
Closes #860

#### What has been done to verify that this works as intended?
Updated the relevant test and did manual testing against https://sandbox.central.opendatakit.org/.

#### Why is this the best possible solution? Were any other approaches considered?
Initially I thought I'd try to support all versions of Central but I decided that it's not worth it. It's relatively easy to upgrade Central and users really shouldn't be running on old versions. As far as we know there's no behavior that was deprecated that would require users to stay on pre-0.8. I did try to give a useful error message in case of trying to push to an older Central so users can recover.

In terms of code structure, I tried to follow existing patterns as much as possible.

The first commit isn't entirely related but it came up because I was going to lower the level of some errors that are showing up in Sentry but then I realized that they weren't intended to show up in Sentry and are only doing so because the last release used the old release logback file. I made sure @yanokwa's release project removes this and updated the readme.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only intentional change is to fix the bug. The only code touched is push to Central and that operation is at risk of regressions.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/getodk/docs/issues/new and include the link below.
No.
