### PR TITLE
Resolve all jr:// URIs to media directory

### DIFF
--- a/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -17,6 +17,7 @@
 
 package org.opendatakit.aggregate.parser;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringReader;
@@ -32,6 +33,7 @@ import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.model.xform.XFormsModule;
 import org.javarosa.xform.parse.XFormParser;
@@ -342,7 +344,7 @@ public class BaseFormParserForJavaRosa implements Serializable {
    *
    * @throws ODKIncompleteSubmissionData
    */
-  protected BaseFormParserForJavaRosa(String existingXml, String existingTitle, boolean allowLegacy)
+  protected BaseFormParserForJavaRosa(String existingXml, String existingTitle, File mediaDirectory, boolean allowLegacy)
       throws ODKIncompleteSubmissionData {
     if (existingXml == null) {
       throw new ODKIncompleteSubmissionData(Reason.MISSING_XML);
@@ -351,6 +353,8 @@ public class BaseFormParserForJavaRosa implements Serializable {
     xml = existingXml;
 
     initializeJavaRosa();
+    ReferenceManager.instance().reset();
+    ReferenceManager.instance().addReferenceFactory(new MediaFileReferenceFactory(mediaDirectory));
 
     XFormParserWithBindEnhancements xfp = parseFormDefinition(xml, this);
     try {
@@ -568,8 +572,8 @@ public class BaseFormParserForJavaRosa implements Serializable {
    *     encryption.
    * @throws ODKIncompleteSubmissionData
    */
-  public static DifferenceResult compareXml(BaseFormParserForJavaRosa incomingParser,
-                                            String existingXml, String existingTitle, boolean isWithinUpdateWindow)
+  public static DifferenceResult compareXml(BaseFormParserForJavaRosa incomingParser, String existingXml,
+                                            String existingTitle, File mediaDirectory, boolean isWithinUpdateWindow)
       throws ODKIncompleteSubmissionData {
     if (incomingParser == null || existingXml == null) {
       throw new ODKIncompleteSubmissionData(Reason.MISSING_XML);
@@ -584,7 +588,7 @@ public class BaseFormParserForJavaRosa implements Serializable {
     FormDef formDef1;
     FormDef formDef2;
     BaseFormParserForJavaRosa existingParser = new BaseFormParserForJavaRosa(existingXml,
-        existingTitle, true);
+        existingTitle, mediaDirectory, true);
     formDef1 = incomingParser.rootJavaRosaFormDef;
     formDef2 = existingParser.rootJavaRosaFormDef;
     if (formDef1 == null || formDef2 == null) {

--- a/src/org/opendatakit/aggregate/parser/MediaFileReferenceFactory.java
+++ b/src/org/opendatakit/aggregate/parser/MediaFileReferenceFactory.java
@@ -1,0 +1,77 @@
+package org.opendatakit.aggregate.parser;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.javarosa.core.reference.InvalidReferenceException;
+import org.javarosa.core.reference.Reference;
+import org.javarosa.core.reference.ReferenceFactory;
+
+/**
+ * ReferenceFactory implementation that resolves any jr:// URI to the specified media folder. Most methods are
+ * unimplemented and throw UnsupportedOperationException if used.
+ */
+@SuppressWarnings("checkstyle:ParameterName")
+public class MediaFileReferenceFactory implements ReferenceFactory {
+  private final File mediaDirectory;
+
+  public MediaFileReferenceFactory(File mediaDirectory) {
+    this.mediaDirectory = mediaDirectory;
+  }
+
+  @Override
+  public boolean derives(String URI) {
+    return true;
+  }
+
+  @Override
+  public Reference derive(String URI) throws InvalidReferenceException {
+    return new Reference() {
+      @Override
+      public String getLocalURI() {
+        return mediaDirectory.getAbsolutePath() + URI.substring(URI.lastIndexOf('/'));
+      }
+
+      @Override
+      public boolean doesBinaryExist() throws IOException {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public InputStream getStream() throws IOException {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public String getURI() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean isReadOnly() {
+        return false;
+      }
+
+      @Override
+      public OutputStream getOutputStream() throws IOException {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void remove() throws IOException {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Reference[] probeAlternativeReferences() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  @Override
+  public Reference derive(String URI, String context) throws InvalidReferenceException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/org/opendatakit/briefcase/model/BriefcaseFormDefinition.java
+++ b/src/org/opendatakit/briefcase/model/BriefcaseFormDefinition.java
@@ -17,6 +17,7 @@
 package org.opendatakit.briefcase.model;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.opendatakit.briefcase.util.FileSystemUtils.getMediaDirectory;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -160,7 +161,8 @@ public class BriefcaseFormDefinition implements IFormDefinition, Serializable {
           // newDefn is considered identical to what we have locally...
           result = DifferenceResult.XFORMS_IDENTICAL;
         } else {
-          result = JavaRosaParserWrapper.compareXml(newDefn, existingXml, existingTitle, true);
+          result = JavaRosaParserWrapper.compareXml(newDefn, existingXml, existingTitle,
+              getMediaDirectory(briefcaseFormDirectory), true);
         }
 
         if (result == DifferenceResult.XFORMS_DIFFERENT) {
@@ -169,6 +171,7 @@ public class BriefcaseFormDefinition implements IFormDefinition, Serializable {
                 newDefn,
                 revisedXml,
                 Objects.requireNonNull(revisedDefn).getFormName(),
+                getMediaDirectory(briefcaseFormDirectory),
                 true
             );
             if (result == DifferenceResult.XFORMS_DIFFERENT) {

--- a/src/org/opendatakit/briefcase/util/FileSystemUtils.java
+++ b/src/org/opendatakit/briefcase/util/FileSystemUtils.java
@@ -164,14 +164,9 @@ public class FileSystemUtils {
     return new File(formDirectory, formDirectory.getName() + ".xml");
   }
 
-  static File getMediaDirectory(File formDirectory)
-      throws FileSystemException {
-    File mediaDir = new File(formDirectory, formDirectory.getName() + "-media");
-    if (!mediaDir.exists() && !mediaDir.mkdirs()) {
-      throw new FileSystemException("unable to create directory: " + mediaDir.getAbsolutePath());
-    }
-
-    return mediaDir;
+  // May or may not actually exist on disk depending on whether the form definition has attached media.
+  public static File getMediaDirectory(File formDirectory) throws FileSystemException {
+    return new File(formDirectory, formDirectory.getName() + "-media");
   }
 
   static File getFormInstancesDirectory(File formDirectory) throws FileSystemException {

--- a/src/org/opendatakit/briefcase/util/JavaRosaParserWrapper.java
+++ b/src/org/opendatakit/briefcase/util/JavaRosaParserWrapper.java
@@ -1,5 +1,7 @@
 package org.opendatakit.briefcase.util;
 
+import static org.opendatakit.briefcase.util.FileSystemUtils.getMediaDirectory;
+
 import java.io.File;
 import org.javarosa.core.model.instance.TreeElement;
 import org.opendatakit.aggregate.exception.ODKIncompleteSubmissionData;
@@ -10,7 +12,7 @@ public class JavaRosaParserWrapper extends BaseFormParserForJavaRosa {
   private final File formDefinitionFile;
 
   public JavaRosaParserWrapper(File formDefinitionFile, String inputXml) throws ODKIncompleteSubmissionData {
-    super(inputXml, null, true);
+    super(inputXml, null, getMediaDirectory(formDefinitionFile.getParentFile()), true);
     this.formDefinitionFile = formDefinitionFile;
   }
 

--- a/test/java/org/opendatakit/briefcase/model/BriefcaseFormDefinitionWithExternalDataTest.java
+++ b/test/java/org/opendatakit/briefcase/model/BriefcaseFormDefinitionWithExternalDataTest.java
@@ -1,0 +1,55 @@
+package org.opendatakit.briefcase.model;
+
+import static java.nio.file.Files.delete;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.opendatakit.briefcase.util.FileSystemUtils.getMediaDirectory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opendatakit.briefcase.util.BadFormDefinition;
+
+public class BriefcaseFormDefinitionWithExternalDataTest {
+  private Path formDir;
+  private Path formFile;
+  private Path mediaDir;
+  private Path mediaFile;
+
+  @Before
+  public void setUp() {
+    try {
+      formDir = Files.createTempDirectory("briefcase_test");
+      formFile = formDir.resolve("form.xml");
+      Path sourceFile = Paths.get(BriefcaseFormDefinitionWithExternalDataTest.class.getResource("form-with-external-secondary-instance.xml").toURI());
+      Files.copy(sourceFile, formFile);
+
+      mediaDir = getMediaDirectory(formDir.toFile()).toPath();
+      Files.createDirectories(mediaDir);
+      mediaFile = mediaDir.resolve("external-xml.xml");
+      Path sourceMedia = Paths.get(BriefcaseFormDefinitionWithExternalDataTest.class.getResource("external-xml.xml").toURI());
+      Files.copy(sourceMedia, mediaFile);
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  @Test
+  public void buildsFormDef_whenDefinitionReferencesExternalSecondaryInstance() throws BadFormDefinition {
+    BriefcaseFormDefinition briefcaseFormDefinition = new BriefcaseFormDefinition(formDir.toFile(), formFile.toFile());
+
+    assertThat(briefcaseFormDefinition.getFormName(), is("Form with external secondary instance"));
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    delete(formFile);
+    delete(mediaFile);
+    delete(mediaDir);
+    delete(formDir);
+  }
+}

--- a/test/resources/org/opendatakit/briefcase/model/external-xml.xml
+++ b/test/resources/org/opendatakit/briefcase/model/external-xml.xml
@@ -1,0 +1,14 @@
+<root>
+  <item>
+    <label>A</label>
+    <name>a</name>
+  </item>
+  <item>
+    <label>B</label>
+    <name>b</name>
+  </item>
+  <item>
+    <label>C</label>
+    <name>c</name>
+  </item>
+</root>

--- a/test/resources/org/opendatakit/briefcase/model/form-with-external-secondary-instance.xml
+++ b/test/resources/org/opendatakit/briefcase/model/form-with-external-secondary-instance.xml
@@ -1,0 +1,22 @@
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml">
+
+  <h:head>
+    <h:title>Form with external secondary instance</h:title>
+    <model>
+      <instance>
+        <data id="external-instance">
+          <first_item_label/>
+        </data>
+      </instance>
+
+      <instance id="external-xml" src="jr://file/external-xml.xml"/>
+
+      <bind nodeset="/data/first_item_label" calculate="instance('external-xml')/item[name = 'a']/label"/>
+    </model>
+  </h:head>
+
+  <h:body>
+  </h:body>
+
+</h:html>


### PR DESCRIPTION
Needed to build a FormDef for files with external secondary instances.

Closes #878

#### What has been done to verify that this works as intended?
Wrote a test that fails with the user-reported error on master. Tried downloading a real form with external secondary instances and then exporting it. @getodk/testers I think it would be good to try with some of the other ones that you have with both xml and csv external instances and a few submissions.

#### Why is this the best possible solution? Were any other approaches considered?
The core of the solution is setting up a `ReferenceFactory` for the singleton `ReferenceManager`. I don't see any alternatives to that. The decision points I saw were around where to actually build the media directory paths and how much of the `ReferenceFactory` to implement. It felt reasonable to make `getMediaDirectory` public and `JavaRosaWrapper` and `BriefcaseFormDefinition` call it.

For the `ReferenceFactory`, I only implemented `getLocalURI` because I believe that's all we need. The other methods throw `UnsupportedOperationException` so we should be able to tell easily if I was wrong. I had all media of every type resolve to the same directory and don't do any check on the `jr://` prefix provided because I consider that a form design concern.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I changed the implementation of `getMediaDirectory` to not create the directory if it didn't exist but just get the path. The only risk I could think of associated with that was when media attachments are present so I verified that. I could have missed something. Other than that the changes are additive so low-risk.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/getodk/docs/issues/new and include the link below.

No.
