### PR TITLE
URI-encode spaces in URLs

### DIFF
--- a/src/org/opendatakit/briefcase/reused/http/Request.java
+++ b/src/org/opendatakit/briefcase/reused/http/Request.java
@@ -83,7 +83,7 @@ public class Request<T> {
   // TODO v2.0 Move this to RequestBuilder, with uri() and isUri()
   URI asUri() {
     try {
-      return url.toURI();
+      return new URI(url.toString().replaceAll(" ", "%20"));
     } catch (URISyntaxException e) {
       throw new BriefcaseException(e);
     }

--- a/test/java/org/opendatakit/briefcase/reused/http/RequestTest.java
+++ b/test/java/org/opendatakit/briefcase/reused/http/RequestTest.java
@@ -17,8 +17,10 @@
 package org.opendatakit.briefcase.reused.http;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -28,6 +30,7 @@ import org.junit.Test;
 public class RequestTest {
 
   private static final String BASE_URL = "http://foo.com";
+  private static final String URL_WITH_SPACE = "http://foo.com/some spaces are here";
 
   @Test
   public void can_map_a_response_body() {
@@ -39,5 +42,11 @@ public class RequestTest {
   @Test
   public void can_return_its_uri() {
     assertThat(RequestBuilder.get(BASE_URL).build().asUri(), instanceOf(URI.class));
+  }
+
+  @Test
+  public void can_return_its_uri_with_encoded_spaces() {
+    assertThat(RequestBuilder.get(URL_WITH_SPACE).build().asUri(), instanceOf(URI.class));
+    assertThat(RequestBuilder.get(URL_WITH_SPACE).build().asUri().toString(), not(containsString(" ")));
   }
 }


### PR DESCRIPTION
Closes #880

#### What has been done to verify that this works as intended?
Ran it with the form from the issue, wrote an automated test. I also pushed that same form and exported it to confirm there were no other issues with a form id with a space.

#### Why is this the best possible solution? Were any other approaches considered?
I initially thought I could use some kind of Java API for this but I don't think so. See https://stackoverflow.com/questions/4737841/urlencoder-not-able-to-translate-space-character. I decided to be very surgical and only handle spaces for now and we can deal with other characters that need to be URI-encoded if they actually come up.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only thing this does is replace spaces in URIs with `%20`. It should be very safe.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/getodk/docs/issues/new and include the link below.
No.
