### PR TITLE
On export, skip submissions that can't be parsed

### DIFF
--- a/src/org/opendatakit/briefcase/export/ExportToCsv.java
+++ b/src/org/opendatakit/briefcase/export/ExportToCsv.java
@@ -37,7 +37,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.bushe.swing.event.EventBus;
 import org.opendatakit.briefcase.model.FormStatus;
 import org.opendatakit.briefcase.model.form.FormMetadata;
@@ -143,14 +142,13 @@ public class ExportToCsv {
   }
 
   private static SubmissionExportErrorCallback buildParsingErrorCallback(Path errorsDir) {
-    AtomicInteger errorSeq = new AtomicInteger(1);
     // Remove errors from a previous export attempt
     if (exists(errorsDir))
       deleteRecursive(errorsDir);
     return (path, message) -> {
       if (!exists(errorsDir))
         createDirectories(errorsDir);
-      copy(path, errorsDir.resolve("failed_submission_" + errorSeq.getAndIncrement() + ".xml"));
+      copy(path, errorsDir.resolve("failed_submission_" + path.getParent().getFileName() + ".xml"));
       log.warn("A submission has been excluded from the export output due to some problem ({}). If you didn't expect this, please ask for support at https://forum.getodk.org/c/support", message);
     };
   }


### PR DESCRIPTION
Closes #874

#### What has been done to verify that this works as intended?
Tried different exports with and without empty submission.xml files. Clearing the contents of a submission.xml file reproduces the original issue. With this PR, the export should be successful, there should be a message in the details saying `Can't export submission ...`, the `-errors` folder should include the failed submission with its instanceID.

#### Why is this the best possible solution? Were any other approaches considered?
This is the only solution I considered once I realized that submissions that were leading to parse errors were included in the submissions to export. This is the simplest way to exclude those submissions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users should get fewer export errors and should have more information to recover from them when they do happen. The regression risk is low because it only affects the path where there's an exception on parse.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/getodk/docs/issues/new and include the link below.
No.