### PR TITLE
Exclude draft form definitions from Central list

### DIFF
--- a/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
+++ b/src/org/opendatakit/briefcase/reused/transfer/CentralServer.java
@@ -231,6 +231,7 @@ public class CentralServer implements RemoteServer {
         .withPath("/v1/projects/" + projectId + "/forms")
         .withHeader("Authorization", "Bearer " + token)
         .withResponseMapper(list -> list.stream()
+            .filter(json -> json.get("publishedAt") != null)
             .map(json -> new RemoteFormDefinition(
                 (String) json.get("name"),
                 (String) json.get("xmlFormId"),

--- a/test/java/org/opendatakit/briefcase/reused/transfer/TransferTestHelpers.java
+++ b/test/java/org/opendatakit/briefcase/reused/transfer/TransferTestHelpers.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -247,11 +250,13 @@ public class TransferTestHelpers {
                     "\t{\n" +
                     "\t  \"xmlFormId\": \"%s\",\n" +
                     "\t  \"name\": \"%s\",\n" +
-                    "\t  \"version\": %s\n" +
+                    "\t  \"version\": %s\n," +
+                    "\t  \"publishedAt\": \"%s\"\n" +
                     "\t}",
                 form.getFormId(),
                 form.getFormName(),
-                form.getFormDefinition().getVersionString() == null ? "null" : "\"" + form.getFormDefinition().getVersionString() + "\""
+                form.getFormDefinition().getVersionString() == null ? "null" : "\"" + form.getFormDefinition().getVersionString() + "\"",
+                ZonedDateTime.now( ZoneOffset.UTC ).format( DateTimeFormatter.ISO_INSTANT )
             ))
             .collect(joining(",\n"))
         + "\n]";


### PR DESCRIPTION
Closes #861 

#### What has been done to verify that this works as intended?
Added a draft form definition to Central project, configured that project as a pull source, verified that the draft form didn't show up in the list.

#### Why is this the best possible solution? Were any other approaches considered?
This filters out drafts which is exactly what we want. I don't see any other possibilities.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the bug. It's a one line change that's very targeted so should truly be very low risk.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/getodk/docs/issues/new and include the link below.
No.