### PR TITLE
When pulling from Central, download submission or attachment files that don't exist

### DIFF
--- a/src/org/opendatakit/briefcase/pull/aggregate/PullFromAggregate.java
+++ b/src/org/opendatakit/briefcase/pull/aggregate/PullFromAggregate.java
@@ -149,7 +149,9 @@ public class PullFromAggregate {
                   submissionAttachments.parallelStream().forEach(attachment ->
                       downloadSubmissionAttachment(form, submission, attachment, rs, tracker, currentSubmissionNumber, totalSubmissions, submissionAttachmentNumber.getAndIncrement(), totalSubmissionAttachments)
                   );
-                  db.putRecordedInstanceDirectory(submission.getInstanceId(), form.getSubmissionDir(briefcaseDir, submission.getInstanceId()).toFile());
+                  if (!rs.isCancelled()) {
+                    db.putRecordedInstanceDirectory(submission.getInstanceId(), form.getSubmissionDir(briefcaseDir, submission.getInstanceId()).toFile());
+                  }
                 });
           });
 

--- a/src/org/opendatakit/briefcase/pull/central/PullFromCentral.java
+++ b/src/org/opendatakit/briefcase/pull/central/PullFromCentral.java
@@ -123,8 +123,10 @@ public class PullFromCentral {
                     .filter(attachment -> !inDb || !form.getSubmissionMediaFile(briefcaseDir, instanceId, attachment.getName()).toFile().exists())
                     .forEach(attachment ->
                         downloadSubmissionAttachment(form, instanceId, attachment, token, runnerStatus, tracker, currentSubmissionNumber, totalSubmissions, attachmentNumber.getAndIncrement(), totalAttachments)
-                );
-                db.putRecordedInstanceDirectory(instanceId, form.getSubmissionDir(briefcaseDir, instanceId).toFile());
+                  );
+                if (!runnerStatus.isCancelled()) {
+                  db.putRecordedInstanceDirectory(instanceId, form.getSubmissionDir(briefcaseDir, instanceId).toFile());
+                }
               });
           tracker.trackEnd();
 

--- a/src/org/opendatakit/briefcase/pull/central/PullFromCentral.java
+++ b/src/org/opendatakit/briefcase/pull/central/PullFromCentral.java
@@ -124,7 +124,7 @@ public class PullFromCentral {
                     .forEach(attachment ->
                         downloadSubmissionAttachment(form, instanceId, attachment, token, runnerStatus, tracker, currentSubmissionNumber, totalSubmissions, attachmentNumber.getAndIncrement(), totalAttachments)
                   );
-                if (!runnerStatus.isCancelled()) {
+                if (!runnerStatus.isCancelled() && !inDb) {
                   db.putRecordedInstanceDirectory(instanceId, form.getSubmissionDir(briefcaseDir, instanceId).toFile());
                 }
               });

--- a/src/org/opendatakit/briefcase/pull/central/PullFromCentralTracker.java
+++ b/src/org/opendatakit/briefcase/pull/central/PullFromCentralTracker.java
@@ -186,46 +186,46 @@ class PullFromCentralTracker {
     notifyTrackingEvent();
   }
 
-  void trackStartGettingSubmissionAttachments(int submissionNumber, int totalSubmissions) {
-    String message = "Start getting attachments of submission " + submissionNumber + " of " + totalSubmissions;
+  void trackStartGettingSubmissionAttachmentList(int submissionNumber, int totalSubmissions) {
+    String message = "  Start getting attachment list of submission " + submissionNumber + " of " + totalSubmissions;
     form.setStatusString(message);
     log.info("Pull {} - {}", form.getFormName(), message);
     notifyTrackingEvent();
   }
 
-  void trackErrorGettingSubmissionAttachments(int submissionNumber, int totalSubmissions, Response response) {
+  void trackErrorGettingSubmissionAttachmentList(String instanceId, Response response) {
     errored = true;
-    String message = "Error getting attachments of submission " + submissionNumber + " of " + totalSubmissions;
+    String message = "  Error getting attachment list of submission " + instanceId;
     form.setStatusString(message + ": " + response.getStatusPhrase());
     log.error("Pull {} - {}: HTTP {} {}", form.getFormName(), message, response.getStatusCode(), response.getStatusPhrase());
     notifyTrackingEvent();
   }
 
 
-  void trackEndGettingSubmissionAttachments(int submissionNumber, int totalSubmissions) {
-    String message = "Got all the attachments of submission " + submissionNumber + " of " + totalSubmissions;
+  void trackEndGettingSubmissionAttachmentList(int submissionNumber, int totalSubmissions) {
+    String message = "  Got attachment list of submission " + submissionNumber + " of " + totalSubmissions;
     form.setStatusString(message);
     log.info("Pull {} - {}", form.getFormName(), message);
     notifyTrackingEvent();
   }
 
   void trackStartDownloadingSubmissionAttachment(int submissionNumber, int totalSubmissions, int attachmentNumber, int totalAttachments) {
-    String message = "Start downloading attachment " + attachmentNumber + " of " + totalAttachments + " of submission " + submissionNumber + " of " + totalSubmissions;
+    String message = "  Start downloading attachment " + attachmentNumber + " of " + totalAttachments + " of submission " + submissionNumber + " of " + totalSubmissions;
     form.setStatusString(message);
     log.info("Pull {} - {}", form.getFormName(), message);
     notifyTrackingEvent();
   }
 
   void trackEndDownloadingSubmissionAttachment(int submissionNumber, int totalSubmissions, int attachmentNumber, int totalAttachments) {
-    String message = "Attachment " + attachmentNumber + " of " + totalAttachments + " of submission " + submissionNumber + " of " + totalSubmissions + " downloaded";
+    String message = "  Attachment " + attachmentNumber + " of " + totalAttachments + " of submission " + submissionNumber + " of " + totalSubmissions + " downloaded";
     form.setStatusString(message);
     log.info("Pull {} - {}", form.getFormName(), message);
     notifyTrackingEvent();
   }
 
-  void trackErrorDownloadingSubmissionAttachment(int submissionNumber, int totalSubmissions, int attachmentNumber, int totalAttachments, Response response) {
+  void trackErrorDownloadingSubmissionAttachment(String instanceId, String attachmentName, Response response) {
     errored = true;
-    String message = "Error downloading attachment " + attachmentNumber + " of " + totalAttachments + " of submission " + submissionNumber + " of " + totalSubmissions;
+    String message = "  Error downloading attachment " + attachmentName + " of submission " + instanceId;
     form.setStatusString(message + ": " + response.getStatusPhrase());
     log.error("Pull {} - {}: HTTP {} {}", form.getFormName(), message, response.getStatusCode(), response.getStatusPhrase());
     notifyTrackingEvent();

--- a/test/java/org/opendatakit/briefcase/pull/central/PullFromCentralIntegrationTest.java
+++ b/test/java/org/opendatakit/briefcase/pull/central/PullFromCentralIntegrationTest.java
@@ -161,12 +161,12 @@ public class PullFromCentralIntegrationTest {
     assertThat(form.getStatusHistory(), containsString("Form attachment 2 of 2 downloaded"));
     assertThat(form.getStatusHistory(), containsString("Start downloading submission 1 of 250"));
     assertThat(form.getStatusHistory(), containsString("Submission 1 of 250 downloaded"));
-    assertThat(form.getStatusHistory(), containsString("Start getting attachments of submission 1 of 250"));
-    assertThat(form.getStatusHistory(), containsString("Got all the attachments of submission 1 of 250"));
+    assertThat(form.getStatusHistory(), containsString("  Start getting attachment list of submission 1 of 250"));
+    assertThat(form.getStatusHistory(), containsString("  Got attachment list of submission 1 of 250"));
     assertThat(form.getStatusHistory(), containsString("Start downloading submission 250 of 250"));
     assertThat(form.getStatusHistory(), containsString("Submission 250 of 250 downloaded"));
-    assertThat(form.getStatusHistory(), containsString("Start getting attachments of submission 250 of 250"));
-    assertThat(form.getStatusHistory(), containsString("Got all the attachments of submission 250 of 250"));
+    assertThat(form.getStatusHistory(), containsString("  Start getting attachment list of submission 250 of 250"));
+    assertThat(form.getStatusHistory(), containsString("  Got attachment list of submission 250 of 250"));
     assertThat(form.getStatusHistory(), containsString("Start downloading attachment 1 of 2 of submission 250 of 250"));
     assertThat(form.getStatusHistory(), containsString("Attachment 1 of 2 of submission 250 of 250 downloaded"));
     assertThat(form.getStatusHistory(), containsString("Start downloading attachment 2 of 2 of submission 250 of 250"));

--- a/test/java/org/opendatakit/briefcase/pull/central/PullFromCentralTest.java
+++ b/test/java/org/opendatakit/briefcase/pull/central/PullFromCentralTest.java
@@ -127,26 +127,6 @@ public class PullFromCentralTest {
   }
 
   @Test
-  public void knows_how_to_download_a_submission() {
-    String instanceId = "uuid:515a13cf-d7a5-4606-a18f-84940b0944b2";
-    String expectedSubmissionXml = buildSubmissionXml(instanceId);
-    Path submissionFile = form.getSubmissionFile(briefcaseDir, instanceId);
-    http.stub(server.getDownloadSubmissionRequest(form.getFormId(), instanceId, submissionFile, token), ok(expectedSubmissionXml));
-
-    pullOp.downloadSubmission(form, instanceId, token, runnerStatus, tracker, 1, 1);
-
-    String actualSubmissionXml = new String(readAllBytes(submissionFile));
-    assertThat(submissionFile, exists());
-    assertThat(actualSubmissionXml, is(expectedSubmissionXml));
-    // There's actually another event from the call to tracker.trackTotalSubmissions(1) in this test.
-    // Since we don't really care about it, we use Matchers.hasItem() instead of Matchers.contains()
-    assertThat(events, contains(
-        "Start downloading submission 1 of 1",
-        "Submission 1 of 1 downloaded"
-    ));
-  }
-
-  @Test
   public void knows_how_to_get_form_attachments() {
     List<CentralAttachment> expectedAttachments = buildAttachments(3);
 
@@ -190,7 +170,7 @@ public class PullFromCentralTest {
   }
 
   @Test
-  public void knows_how_to_get_submission() {
+  public void knows_how_to_get_submission_list() {
     List<String> expectedInstanceIds = IntStream.range(0, 250)
         .mapToObj(i -> "submission instanceID " + i)
         .collect(Collectors.toList());
@@ -206,6 +186,26 @@ public class PullFromCentralTest {
     assertThat(events, contains(
         "Start getting submission IDs",
         "Got all the submission IDs"
+    ));
+  }
+
+  @Test
+  public void knows_how_to_download_a_submission() {
+    String instanceId = "uuid:515a13cf-d7a5-4606-a18f-84940b0944b2";
+    String expectedSubmissionXml = buildSubmissionXml(instanceId);
+    Path submissionFile = form.getSubmissionFile(briefcaseDir, instanceId);
+    http.stub(server.getDownloadSubmissionRequest(form.getFormId(), instanceId, submissionFile, token), ok(expectedSubmissionXml));
+
+    pullOp.downloadSubmission(form, instanceId, token, runnerStatus, tracker, 1, 1);
+
+    String actualSubmissionXml = new String(readAllBytes(submissionFile));
+    assertThat(submissionFile, exists());
+    assertThat(actualSubmissionXml, is(expectedSubmissionXml));
+    // There's actually another event from the call to tracker.trackTotalSubmissions(1) in this test.
+    // Since we don't really care about it, we use Matchers.hasItem() instead of Matchers.contains()
+    assertThat(events, contains(
+        "Start downloading submission 1 of 1",
+        "Submission 1 of 1 downloaded"
     ));
   }
 

--- a/test/java/org/opendatakit/briefcase/pull/central/PullFromCentralTest.java
+++ b/test/java/org/opendatakit/briefcase/pull/central/PullFromCentralTest.java
@@ -224,8 +224,8 @@ public class PullFromCentralTest {
       assertThat(expectedAttachments, hasItem(attachment));
 
     assertThat(events, contains(
-        "Start getting attachments of submission 1 of 1",
-        "Got all the attachments of submission 1 of 1"
+        "  Start getting attachment list of submission 1 of 1",
+        "  Got attachment list of submission 1 of 1"
     ));
   }
 
@@ -242,12 +242,12 @@ public class PullFromCentralTest {
     expectedAttachments.forEach(attachment -> assertThat(form.getSubmissionMediaFile(briefcaseDir, instanceId, attachment.getName()), exists()));
 
     assertThat(events, contains(
-        "Start downloading attachment 1 of 3 of submission 1 of 1",
-        "Attachment 1 of 3 of submission 1 of 1 downloaded",
-        "Start downloading attachment 2 of 3 of submission 1 of 1",
-        "Attachment 2 of 3 of submission 1 of 1 downloaded",
-        "Start downloading attachment 3 of 3 of submission 1 of 1",
-        "Attachment 3 of 3 of submission 1 of 1 downloaded"
+        "  Start downloading attachment 1 of 3 of submission 1 of 1",
+        "  Attachment 1 of 3 of submission 1 of 1 downloaded",
+        "  Start downloading attachment 2 of 3 of submission 1 of 1",
+        "  Attachment 2 of 3 of submission 1 of 1 downloaded",
+        "  Start downloading attachment 3 of 3 of submission 1 of 1",
+        "  Attachment 3 of 3 of submission 1 of 1 downloaded"
     ));
   }
 }

--- a/test/java/org/opendatakit/briefcase/pull/central/PullFromCentralTest.java
+++ b/test/java/org/opendatakit/briefcase/pull/central/PullFromCentralTest.java
@@ -218,7 +218,7 @@ public class PullFromCentralTest {
         ok(jsonOfAttachments(expectedAttachments))
     );
 
-    List<CentralAttachment> actualAttachments = pullOp.getSubmissionAttachments(form, instanceId, token, runnerStatus, tracker, 1, 1);
+    List<CentralAttachment> actualAttachments = pullOp.getSubmissionAttachmentList(form, instanceId, token, runnerStatus, tracker, 1, 1);
     assertThat(actualAttachments, hasSize(expectedAttachments.size()));
     for (CentralAttachment attachment : actualAttachments)
       assertThat(expectedAttachments, hasItem(attachment));

--- a/test/java/org/opendatakit/briefcase/reused/transfer/TransferTestHelpers.java
+++ b/test/java/org/opendatakit/briefcase/reused/transfer/TransferTestHelpers.java
@@ -48,7 +48,7 @@ import org.opendatakit.briefcase.reused.Pair;
 public class TransferTestHelpers {
   public static String buildSubmissionXml(String instanceId) {
     return "" +
-        "<some-form id=\"some-form\" instanceID=\"" + instanceId + "\" submissionDate=\"2018-07-19T10:36:50.779Z\" isComplete=\"true\" markedAsCompleteDate=\"2018-07-19T10:36:50.779Z\">\n" +
+        "<some-form xmlns:orx=\"http://openrosa.org/xforms\" id=\"some-form\" instanceID=\"" + instanceId + "\" submissionDate=\"2018-07-19T10:36:50.779Z\" isComplete=\"true\" markedAsCompleteDate=\"2018-07-19T10:36:50.779Z\">\n" +
         "  <orx:meta>\n" +
         "    <orx:instanceID>" + instanceId + "</orx:instanceID>\n" +
         "  </orx:meta>\n" +


### PR DESCRIPTION
Closes #886

Prior to this change, submissions whose instanceIDs were in the instance database were filtered out when doing a pull from Central. The problem is that presence in the db does not mean any file was successfully saved for that instance. One change I made to address this is to not save an instanceID to the database if the pull task has been cancelled. **I made this change to pull from Aggregate as well.** What this should mean is that if a pull is cancelled, the submission(s) that are being downloaded at the time should not be skipped on a subsequent pull.

For Central, I also changed when the database is checked for an instance. Prior to this change, if an instanceID were in the database, the submission would be skipped entirely. Now, if the submission is in the database, we:
- check for the presence of a submission file on disk and download it if it doesn't exist
- download the attachment list
- for each attachment, check if it exists on disk and download it if not

This means that there's going to be an extra disk check and an extra request for every single submission to get the attachment list. As a result, subsequent pulls will be slower, even for forms with no attachments (we still need to make the request to know there are no expected attachments). I think the tradeoff is worth it to ensure getting all media files in case of "success with errors".

I did **not** make the corresponding change for Aggregate. This is because there is no API endpoint to get a submission attachment listing. Getting it requires pulling the submission contents as well. We know we have Aggregate users for whom performance is quite important so the tradeoff did not seem worth it in this case. This means that when there's a "success with errors" case in Aggregate, some media could be missing even after a subsequent pull.

#### What has been done to verify that this works as intended?
Pulled from https://test.central.getodk.org/#/projects/149/forms/build_media_1556624635/submissions, cancelled, verified some media was missing, pulled again, verified the media was present. I also manually deleted all contents of an instance's directory, just the submission file, just an attachment and confirmed that the missing files were downloaded on a subsequent pull.

#### Why is this the best possible solution? Were any other approaches considered?
See discussion of tradeoffs above. I also changed the logging messages for submission attachments a little bit to visually link them to their submission and to provide a submission filename and instanceID in case of failure so those are easier to trace.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The biggest risk is that subsequent pulls from Central could be too slow to be practical in certain contexts. I don't think that's the case but it would depend on connection latency to a specific server and disk speed.

I did have to make a number of changes to the pull from Central flow so there's regression risk there. There should be no risk to pull from Aggregate because the only change I made was an added check on whether the pull was cancelled.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/getodk/docs/issues/new and include the link below.
No.
