### PR TITLE
Small fix to remove the csv qualifier and \n from text before generating csv file.

### DIFF
--- a/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
+++ b/src/org/opendatakit/briefcase/export/CsvSubmissionMappers.java
@@ -131,7 +131,7 @@ final class CsvSubmissionMappers {
     if (string == null || string.isEmpty())
       return allowNulls ? "" : "\"\"";
     if (string.contains("\n") || string.contains("\"") || string.contains(","))
-      return String.format("\"%s\"", string.replaceAll("\"", "\"\""));
+      return String.format("\"%s\"", string.replaceAll("\"|\\n", " "));
     return string;
   }
 


### PR DESCRIPTION
Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/getodk/docs/issues/new and include the link below.
