### PR TITLE
On export, skip encrypted submissions with manifest but no .enc file …

### DIFF
--- a/src/org/opendatakit/briefcase/export/SubmissionParser.java
+++ b/src/org/opendatakit/briefcase/export/SubmissionParser.java
@@ -84,7 +84,14 @@ class SubmissionParser {
           Path submissionFile = instanceDir.resolve("submission.xml");
           try {
             Optional<OffsetDateTime> submissionDate = readSubmissionDate(submissionFile);
-            paths.add(Pair.of(submissionFile, submissionDate.orElse(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC))));
+            if (formDef.isFileEncryptedForm() && !Files.exists(instanceDir.resolve("submission.xml.enc")))
+            {
+              log.info(String.format("Can't find encrypted form file (submission.xml.enc) in %s", instanceDir.getFileName()));
+            }
+            else
+            {
+              paths.add(Pair.of(submissionFile, submissionDate.orElse(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC))));
+            }
           } catch (Throwable t) {
             log.error("Can't read submission date", t);
             EventBus.publish(ExportEvent.failureSubmission(formDef, instanceDir.getFileName().toString(), t));


### PR DESCRIPTION
…and mark as failed #895

Closes #

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/getodk/docs/issues/new and include the link below.
